### PR TITLE
Add VR support :)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -72,19 +72,6 @@
 				"vs2022-windows"
 			],
 			"name": "skyrim"
-		},
-		{
-			"binaryDir": "${sourceDir}/build/vr",
-			"cacheVariables": {
-				"BUILD_SKYRIMVR": true
-			},
-			"inherits": [
-				"cmake-dev",
-				"vcpkg",
-				"windows",
-				"vs2022-windows"
-			],
-			"name": "vr"
 		}
 	],
 	"version": 3

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,12 +65,6 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Query(const SKSE::QueryInterface* a
 		return false;
 	}
 
-	const auto ver = a_skse->RuntimeVersion();
-	if (ver < SKSE::RUNTIME_SSE_1_5_39) {
-		logger::critical(FMT_STRING("Unsupported runtime version {}"), ver.string());
-		return false;
-	}
-
 	return true;
 }
 
@@ -81,7 +75,7 @@ extern "C" DLLEXPORT constinit auto SKSEPlugin_Version = []() {
 	v.PluginName(Plugin::NAME);
 
 	v.UsesAddressLibrary(true);
-	v.CompatibleVersions({ SKSE::RUNTIME_SSE_LATEST_AE });
+	v.CompatibleVersions({ SKSE::RUNTIME_SSE_LATEST_AE, SKSE::RUNTIME_LATEST_VR });
 	v.HasNoStructUse(true);
 
 	return v;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,7 +11,7 @@
             "description": "Build the SKSE plugin.",
           "dependencies": [
             "boost-stl-interfaces",
-            "commonlibsse-ng-flatrim",
+            "commonlibsse-ng",
             "simpleini",
             "rsm-binary-io"
           ]


### PR DESCRIPTION
Hope you don't mind, this PR just adds VR support by switching to clib-ng instead of clib-ng-flatrim and marking VR (1.4.15) as compatible.

PR to add the missing VR address into address library for your hook can be found here: https://github.com/alandtse/vr_address_tools/pull/15

The VR address PR will need to be merged for VR users to use it (and they'll need the latest version :P). I also tested this on VR and confirmed stamina doesn't drain :)